### PR TITLE
Parallelize season simulations

### DIFF
--- a/simulate_season.py
+++ b/simulate_season.py
@@ -1,14 +1,11 @@
 import csv
-import random
 import numpy as np
 from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor
 import logging
 import os
 from tiebreakers import apply_tiebreakers
 from playoff_analysis import determine_wild_cards_with_tiebreakers
-import json
-from datetime import datetime
-from tqdm import tqdm
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -62,22 +59,50 @@ VALID_SCORES = np.array([
 COMMON_SCORES = {0, 3, 6, 7, 10, 13, 14, 17, 20, 21, 24, 27, 28, 31, 34, 35}
 SCORE_WEIGHTS = np.array([3 if score in COMMON_SCORES else 1 for score in VALID_SCORES])
 
-# Load data
-schedule = load_schedule()
-teams = load_teams()
-ratings = load_ratings()
+# Default RNG used when no specific generator is provided
+GLOBAL_RNG = np.random.default_rng()
 
-def _fast_score_calculation(expected_total, predicted_spread, volatility=13.5):
+
+def _head_to_head_default():
+    return {'wins': 0, 'losses': 0, 'ties': 0}
+
+
+def _common_games_default():
+    return {'wins': 0, 'losses': 0, 'ties': 0}
+
+
+def _team_record_default():
+    return {
+        'wins': 0,
+        'losses': 0,
+        'ties': 0,
+        'division_wins': 0,
+        'division_losses': 0,
+        'division_ties': 0,
+        'conference_wins': 0,
+        'conference_losses': 0,
+        'conference_ties': 0,
+        'head_to_head': defaultdict(_head_to_head_default),
+        'opponents': set(),
+        'defeated_opponents': set(),
+        'common_games': defaultdict(_common_games_default),
+        'points_for': 0,
+        'points_against': 0
+    }
+
+def _fast_score_calculation(expected_total, predicted_spread, volatility=13.5, rng=None):
     """Optimized core score calculation"""
-    actual_spread = np.random.normal(predicted_spread, volatility)
-    actual_total = np.random.normal(expected_total, 10)
+    rng = GLOBAL_RNG if rng is None else rng
+
+    actual_spread = rng.normal(predicted_spread, volatility)
+    actual_total = rng.normal(expected_total, 10)
     
     home_score = (actual_total + actual_spread) / 2
     away_score = (actual_total - actual_spread) / 2
     
     return max(0, round(home_score)), max(0, round(away_score))
 
-def generate_random_score(expected_total, predicted_spread, volatility=13.5):
+def generate_random_score(expected_total, predicted_spread, volatility=13.5, rng=None):
     """
     Generate a random but plausible NFL score with reduced ties
     
@@ -90,27 +115,29 @@ def generate_random_score(expected_total, predicted_spread, volatility=13.5):
     """
     max_attempts = 3  # Try up to 3 times to generate non-tie scores
     
-    home_score, away_score = _fast_score_calculation(expected_total, predicted_spread, volatility)
+    rng = GLOBAL_RNG if rng is None else rng
+
+    home_score, away_score = _fast_score_calculation(expected_total, predicted_spread, volatility, rng=rng)
         
         # Adjust to valid football scores
-    home_score = adjust_to_football_score(home_score)
-    away_score = adjust_to_football_score(away_score)
+    home_score = adjust_to_football_score(home_score, rng=rng)
+    away_score = adjust_to_football_score(away_score, rng=rng)
     
     # If we still have a tie after max attempts, adjust one team's score
     if home_score == away_score:
-        if np.random.random() > 0.01: # rarely keep it a tie
+        if rng.random() > 0.01: # rarely keep it a tie
             # Get valid scores within 3 points (typical FG range) of current score
             nearby_scores = [s for s in VALID_SCORES if 0 < abs(s - home_score) <= 3]
             if nearby_scores:
                 # Adjust score based on predicted spread direction
                 if predicted_spread > 0:
-                    home_score = int(np.random.choice(nearby_scores))
+                    home_score = int(rng.choice(nearby_scores))
                 else:
-                    away_score = int(np.random.choice(nearby_scores))
+                    away_score = int(rng.choice(nearby_scores))
     
     return home_score, away_score
 
-def simulate_game(home_team, away_team, ratings, home_field_advantage):
+def simulate_game(home_team, away_team, ratings, home_field_advantage, rng=None):
     """
     Simulate NFL game using Sagarin ratings with realistic scoring
     
@@ -136,11 +163,13 @@ def simulate_game(home_team, away_team, ratings, home_field_advantage):
     expected_total = 44  # Average NFL game total
     volatility = 13.5  # Standard deviation of spread
     
-    home_score, away_score = generate_random_score(expected_total, predicted_spread, volatility)
+    rng = GLOBAL_RNG if rng is None else rng
+
+    home_score, away_score = generate_random_score(expected_total, predicted_spread, volatility, rng=rng)
         
     # Adjust scores to common NFL numbers
-    home_score = adjust_to_football_score(home_score)
-    away_score = adjust_to_football_score(away_score)
+    home_score = adjust_to_football_score(home_score, rng=rng)
+    away_score = adjust_to_football_score(away_score, rng=rng)
     
     return {
         'home_score': home_score,
@@ -148,7 +177,7 @@ def simulate_game(home_team, away_team, ratings, home_field_advantage):
         'home_win': home_score > away_score
     }
 
-def adjust_to_football_score(score):
+def adjust_to_football_score(score, rng=None):
     """
     Adjust a score to valid NFL scoring combinations - maintained original logic
     """
@@ -160,9 +189,10 @@ def adjust_to_football_score(score):
     # If multiple scores are equally close, weight toward common scores
     if len(closest_indices) > 1:
         closest_scores = VALID_SCORES[closest_indices]
+        rng = GLOBAL_RNG if rng is None else rng
         score_weights = [3 if s in COMMON_SCORES else 1 for s in closest_scores]
-        return int(np.random.choice(closest_scores, p=np.array(score_weights)/sum(score_weights)))
-    
+        return int(rng.choice(closest_scores, p=np.array(score_weights)/sum(score_weights)))
+
     return int(VALID_SCORES[closest_indices[0]])
 
 
@@ -197,24 +227,8 @@ def determine_division_winners(standings, teams):
     
     return division_winners
 
-def initialize_standings(schedule):
-    standings = defaultdict(lambda: {
-        'wins': 0, 
-        'losses': 0, 
-        'ties': 0,
-        'division_wins': 0,
-        'division_losses': 0,
-        'division_ties': 0,
-        'conference_wins': 0,
-        'conference_losses': 0,
-        'conference_ties': 0,
-        'head_to_head': defaultdict(lambda: {'wins': 0, 'losses': 0, 'ties': 0}),
-        'opponents': set(),
-        'defeated_opponents': set(),
-        'common_games': defaultdict(lambda: {'wins': 0, 'losses': 0, 'ties': 0}),
-        'points_for': 0,
-        'points_against': 0
-    })
+def initialize_standings(schedule, teams):
+    standings = defaultdict(_team_record_default)
     
     for game in schedule:
         # Skip games that haven't been played
@@ -286,7 +300,7 @@ def initialize_standings(schedule):
             
     return standings
 
-def calculate_rating_adjustment(home_score, away_score, base_adjustment=0.5):
+def calculate_rating_adjustment(home_score, away_score, base_adjustment=0.5, rng=None):
     """
     Calculate rating adjustment based on margin of victory and randomness
     
@@ -306,7 +320,9 @@ def calculate_rating_adjustment(home_score, away_score, base_adjustment=0.5):
     margin_factor = np.log(margin + 1) / 2.5  # +1 to handle 0 margin
     
     # Add some randomness (between 0.8 and 1.2 of calculated adjustment)
-    random_factor = np.random.uniform(0.8, 1.2)
+    rng = GLOBAL_RNG if rng is None else rng
+
+    random_factor = rng.uniform(0.8, 1.2)
     
     # Calculate final adjustment
     adjustment = base_adjustment * margin_factor * random_factor
@@ -318,167 +334,182 @@ def calculate_rating_adjustment(home_score, away_score, base_adjustment=0.5):
     # Cap maximum adjustment at 2x base_adjustment
     return adjustment
 
-def simulate_season(test_schedule=None, num_simulations=1, home_field_advantage=2.5):
-    # Load initial data
+def _simulate_single_season(schedule, teams, base_ratings, home_field_advantage, seed, include_schedule):
+    rng = np.random.default_rng(seed)
+
+    ratings = dict(base_ratings)
+    standings = initialize_standings(schedule, teams)
+    game_results = []
+    schedule_output = [game.copy() for game in schedule] if include_schedule else None
+
+    for game in schedule:
+        if game['away_score'] and game['home_score']:
+            game_results.append({
+                'home_team': game['home_team'],
+                'away_team': game['away_team'],
+                'home_score': int(game['home_score']),
+                'away_score': int(game['away_score'])
+            })
+
+    for game in schedule:
+        if not game['away_score'] and not game['home_score']:
+            home_team = game['home_team']
+            away_team = game['away_team']
+            result = simulate_game(home_team, away_team, ratings, home_field_advantage, rng=rng)
+
+            adjustment = calculate_rating_adjustment(
+                result['home_score'],
+                result['away_score'],
+                rng=rng
+            )
+
+            if result['home_win']:
+                ratings[home_team] += adjustment
+                ratings[away_team] -= adjustment
+            else:
+                ratings[away_team] += adjustment
+                ratings[home_team] -= adjustment
+
+            ratings[home_team] = round(ratings[home_team], 2)
+            ratings[away_team] = round(ratings[away_team], 2)
+
+            if result['home_win']:
+                standings[home_team]['wins'] += 1
+                standings[away_team]['losses'] += 1
+                standings[home_team]['head_to_head'][away_team]['wins'] += 1
+                standings[away_team]['head_to_head'][home_team]['losses'] += 1
+            else:
+                standings[away_team]['wins'] += 1
+                standings[home_team]['losses'] += 1
+                standings[home_team]['head_to_head'][away_team]['losses'] += 1
+                standings[away_team]['head_to_head'][home_team]['wins'] += 1
+
+            game_results.append({
+                'home_team': home_team,
+                'away_team': away_team,
+                'home_score': result['home_score'],
+                'away_score': result['away_score']
+            })
+
+            if include_schedule and schedule_output is not None:
+                for game_entry in schedule_output:
+                    if (game_entry['home_team'] == home_team and
+                        game_entry['away_team'] == away_team):
+                        game_entry['home_score'] = str(result['home_score'])
+                        game_entry['away_score'] = str(result['away_score'])
+                        break
+
+    division_winners = determine_division_winners(standings, teams)
+
+    wild_cards = determine_wild_cards_with_tiebreakers(standings, teams, division_winners, {
+        'game_results': game_results
+    })
+
+    playoff_order = {}
+    for conference in ['AFC', 'NFC']:
+        conf_div_winners = [team for team in division_winners
+                            if teams[team]['conference'] == conference]
+
+        div_winner_groups = defaultdict(list)
+        for team in conf_div_winners:
+            win_pct = standings[team]['wins'] / (standings[team]['wins'] + standings[team]['losses'] + standings[team].get('ties', 0))
+            div_winner_groups[win_pct].append(team)
+
+        sorted_div_winners = []
+        for win_pct in sorted(div_winner_groups.keys(), reverse=True):
+            teams_in_group = div_winner_groups[win_pct]
+            if len(teams_in_group) > 1:
+                sorted_group = apply_tiebreakers(teams_in_group, standings)
+                sorted_div_winners.extend(sorted_group)
+            else:
+                sorted_div_winners.extend(teams_in_group)
+
+        conf_wild_cards = wild_cards.get(conference, [])
+
+        logger.info(f"\n{conference} Final Playoff Seeds:")
+        for i, team in enumerate(sorted_div_winners + conf_wild_cards, 1):
+            record = standings[team]
+            logger.info(f"#{i} Seed: {team} ({record['wins']}-{record['losses']}-{record.get('ties', 0)})")
+
+        playoff_order[conference] = sorted_div_winners + conf_wild_cards
+
+    afc_champion = determine_conference_champion('AFC', division_winners, wild_cards, standings, teams, ratings, home_field_advantage, rng=rng)
+    nfc_champion = determine_conference_champion('NFC', division_winners, wild_cards, standings, teams, ratings, home_field_advantage, rng=rng)
+
+    super_bowl_result = {
+        'teams': [afc_champion, nfc_champion],
+        'winner': simulate_super_bowl(afc_champion, nfc_champion, ratings, home_field_advantage, rng=rng)
+    }
+
+    result_payload = {
+        'standings': standings,
+        'division_winners': division_winners,
+        'wild_cards': wild_cards,
+        'playoff_order': playoff_order,
+        'game_results': game_results,
+        'super_bowl': super_bowl_result
+    }
+
+    return result_payload, schedule_output
+
+
+def _simulate_single_season_wrapper(args):
+    return _simulate_single_season(*args)
+
+
+def simulate_season(
+    test_schedule=None,
+    num_simulations=1,
+    home_field_advantage=2.5,
+    random_seed=None,
+    parallel=True,
+    max_workers=None
+):
     schedule = load_schedule()
     teams = load_teams()
-        
-    results = []
-    for sim_num in range(num_simulations):
-        # Reset ratings to original values at start of each simulation
-        ratings = load_ratings()  # Fresh copy for each simulation
-        
-        # Initialize standings with actual played games first
-        standings = initialize_standings(schedule)
-        game_results = []
-        
-        # Track game results for analysis
-        game_results = []
-        
-        # Create a copy of schedule for the test file
-        if sim_num == 0:  # Only for first simulation
-            test_schedule = []
-            for game in schedule:
-                test_schedule.append(game.copy())
-                # Add played games to game_results
-                if game['away_score'] and game['home_score']:
-                    game_results.append({
-                        'home_team': game['home_team'],
-                        'away_team': game['away_team'],
-                        'home_score': int(game['home_score']),
-                        'away_score': int(game['away_score'])
-                    })
-        
-        # Simulate remaining games
-        for game in schedule:
-            if not game['away_score'] and not game['home_score']:  # Future games only
-                home_team = game['home_team']
-                away_team = game['away_team']
-                result = simulate_game(home_team, away_team, ratings, home_field_advantage)
-                
-                # Calculate dynamic rating adjustment
-                adjustment = calculate_rating_adjustment(
-                    result['home_score'], 
-                    result['away_score']
-                )
-                
-                original_home_rating = round(ratings[home_team], 2)
-                original_away_rating = round(ratings[away_team], 2)
+    base_ratings = load_ratings()
 
-                # Apply adjustment based on winner
-                if result['home_win']:
-                    ratings[home_team] += adjustment
-                    ratings[away_team] -= adjustment
-                else:
-                    ratings[away_team] += adjustment
-                    ratings[home_team] -= adjustment
+    include_schedule = test_schedule is not None
 
-                ratings[home_team] = round(ratings[home_team], 2)
-                ratings[away_team] = round(ratings[away_team], 2)
-                
-                # print(f" => Adjusted ratings for {home_team} ({result['home_score']} v {result['away_score']}) : {original_home_rating} -> {ratings[home_team]}")
-                # print(f" => Adjusted ratings for {away_team} ({result['away_score']} v {result['home_score']}) : {original_away_rating} -> {ratings[away_team]}")
+    seed_sequence = np.random.SeedSequence(random_seed)
+    child_seeds = seed_sequence.spawn(num_simulations)
+    seed_values = [int(child.generate_state(1)[0]) for child in child_seeds] if num_simulations > 0 else []
 
-                if result['home_win']:
-                    standings[home_team]['wins'] += 1
-                    standings[away_team]['losses'] += 1
-                    standings[home_team]['head_to_head'][away_team]['wins'] += 1
-                    standings[away_team]['head_to_head'][home_team]['losses'] += 1
-                else:
-                    standings[away_team]['wins'] += 1
-                    standings[home_team]['losses'] += 1
-                    standings[home_team]['head_to_head'][away_team]['losses'] += 1
-                    standings[away_team]['head_to_head'][home_team]['wins'] += 1
-                
-                game_results.append({
-                    'home_team': home_team,
-                    'away_team': away_team,
-                    'home_score': result['home_score'],
-                    'away_score': result['away_score']
-                })
-                
-                # Add simulated game to test schedule on first simulation
-                if sim_num == 0:
-                    for game_entry in test_schedule:
-                        if (game_entry['home_team'] == home_team and 
-                            game_entry['away_team'] == away_team):
-                            game_entry['home_score'] = str(result['home_score'])
-                            game_entry['away_score'] = str(result['away_score'])
-                                                    
-        # Calculate division winners
-        division_winners = determine_division_winners(standings, teams)
-                
-        # Use the full tiebreaker logic for wild cards during simulation
-        wild_cards = determine_wild_cards_with_tiebreakers(standings, teams, division_winners, {
-            'game_results': game_results
-        })
-        
-        # Calculate playoff order for each conference
-        playoff_order = {}
-        for conference in ['AFC', 'NFC']:
-            # Get division winners from this conference
-            conf_div_winners = [team for team in division_winners 
-                              if teams[team]['conference'] == conference]
-            
-            # First group division winners by win percentage
-            div_winner_groups = defaultdict(list)
-            for team in conf_div_winners:
-                win_pct = standings[team]['wins'] / (standings[team]['wins'] + standings[team]['losses'] + standings[team].get('ties', 0))
-                div_winner_groups[win_pct].append(team)
-            
-            # Process each group with tiebreakers
-            sorted_div_winners = []
-            for win_pct in sorted(div_winner_groups.keys(), reverse=True):
-                teams_in_group = div_winner_groups[win_pct]
-                if len(teams_in_group) > 1:
-                    # Apply tiebreakers between division winners with same record
-                    sorted_group = apply_tiebreakers(teams_in_group, standings)
-                    sorted_div_winners.extend(sorted_group)
-                else:
-                    sorted_div_winners.extend(teams_in_group)
-            
-            # Get wild card teams for this conference (seeds 5-7)
-            conf_wild_cards = wild_cards.get(conference, [])
-            
-            # Debug log the final seeding
-            logger.info(f"\n{conference} Final Playoff Seeds:")
-            for i, team in enumerate(sorted_div_winners + conf_wild_cards, 1):
-                record = standings[team]
-                logger.info(f"#{i} Seed: {team} ({record['wins']}-{record['losses']}-{record.get('ties', 0)})")
-            
-            # Store final playoff order
-            playoff_order[conference] = sorted_div_winners + conf_wild_cards
-        
-        # Simulate conference championships and Super Bowl
-        afc_champion = determine_conference_champion('AFC', division_winners, wild_cards, standings, teams, ratings, home_field_advantage)
-        nfc_champion = determine_conference_champion('NFC', division_winners, wild_cards, standings, teams, ratings, home_field_advantage)
-        
-        super_bowl_result = {
-            'teams': [afc_champion, nfc_champion],
-            'winner': simulate_super_bowl(afc_champion, nfc_champion, ratings, home_field_advantage)
-        }
-        
-        # Store the results
-        results.append({
-            'standings': standings,
-            'division_winners': division_winners,
-            'wild_cards': wild_cards,
-            'playoff_order': playoff_order,
-            'game_results': game_results,
-            'super_bowl': super_bowl_result  # Add Super Bowl results
-        })
+    args_list = [
+        (
+            schedule,
+            teams,
+            base_ratings,
+            home_field_advantage,
+            seed_values[sim_idx],
+            include_schedule and sim_idx == 0
+        )
+        for sim_idx in range(num_simulations)
+    ]
 
-        sim_end_time = datetime.now()
-        # print(f"Simulation {sim_num} took {sim_end_time - sim_start_time} seconds")
-        
+    if parallel and num_simulations > 1:
+        worker_count = min(max_workers or os.cpu_count() or 1, num_simulations)
+        with ProcessPoolExecutor(max_workers=worker_count) as executor:
+            outputs = list(executor.map(_simulate_single_season_wrapper, args_list))
+    else:
+        outputs = [_simulate_single_season_wrapper(args) for args in args_list]
+
+    results = [payload for payload, _ in outputs]
+
+    if include_schedule and test_schedule is not None and outputs:
+        schedule_output = outputs[0][1]
+        if schedule_output is not None:
+            test_schedule.clear()
+            test_schedule.extend(schedule_output)
+
     return results
 
-def simulate_playoff_game(home_team, away_team, ratings, home_field_advantage):
+def simulate_playoff_game(home_team, away_team, ratings, home_field_advantage, rng=None):
     """Simulate a playoff game with increased variance"""
     # Use higher volatility for playoff games
-    return simulate_game(home_team, away_team, ratings, home_field_advantage)
+    return simulate_game(home_team, away_team, ratings, home_field_advantage, rng=rng)
 
-def determine_conference_champion(conference, division_winners, wild_cards, standings, teams, ratings, home_field_advantage):
+def determine_conference_champion(conference, division_winners, wild_cards, standings, teams, ratings, home_field_advantage, rng=None):
     """
     Fix the playoff bracket to simulate wildcard -> divisional -> conference championship with the 7-team format.
     """
@@ -509,7 +540,7 @@ def determine_conference_champion(conference, division_winners, wild_cards, stan
 
     wildcard_winners = []
     for home, away in wc_pairs:
-        result = simulate_playoff_game(home, away, ratings, home_field_advantage)
+        result = simulate_playoff_game(home, away, ratings, home_field_advantage, rng=rng)
         winner = home if result['home_win'] else away
         wildcard_winners.append(winner)
 
@@ -529,25 +560,25 @@ def determine_conference_champion(conference, division_winners, wild_cards, stan
     # #1 seed hosts the lowest seed of the wildcard winners (i.e. last in this sorted list)
     dr_game1_home = seed1
     dr_game1_away = wildcard_winners[-1]
-    result1 = simulate_playoff_game(dr_game1_home, dr_game1_away, ratings, home_field_advantage)
+    result1 = simulate_playoff_game(dr_game1_home, dr_game1_away, ratings, home_field_advantage, rng=rng)
     dr_winner1 = dr_game1_home if result1['home_win'] else dr_game1_away
 
     # The other two wildcard winners face off
     dr_game2_home = wildcard_winners[0]
     dr_game2_away = wildcard_winners[1]
-    result2 = simulate_playoff_game(dr_game2_home, dr_game2_away, ratings, home_field_advantage)
+    result2 = simulate_playoff_game(dr_game2_home, dr_game2_away, ratings, home_field_advantage, rng=rng)
     dr_winner2 = dr_game2_home if result2['home_win'] else dr_game2_away
 
     # 3) Conference championship round:
     cc_home = dr_winner1
     cc_away = dr_winner2
-    cc_result = simulate_playoff_game(cc_home, cc_away, ratings, home_field_advantage)
+    cc_result = simulate_playoff_game(cc_home, cc_away, ratings, home_field_advantage, rng=rng)
     conference_champion = cc_home if cc_result['home_win'] else cc_away
 
     return conference_champion
 
-def simulate_super_bowl(afc_team, nfc_team, ratings, home_field_advantage):
+def simulate_super_bowl(afc_team, nfc_team, ratings, home_field_advantage, rng=None):
     """Simulate Super Bowl game"""
     # Neutral field, so use half home field advantage
-    result = simulate_game(afc_team, nfc_team, ratings, home_field_advantage / 2)
+    result = simulate_game(afc_team, nfc_team, ratings, home_field_advantage / 2, rng=rng)
     return afc_team if result['home_win'] else nfc_team

--- a/simulate_season.py
+++ b/simulate_season.py
@@ -472,6 +472,9 @@ def simulate_season(
     include_schedule = test_schedule is not None
 
     seed_sequence = np.random.SeedSequence(random_seed)
+    # Get the actual seed that was used (entropy if random_seed was None)
+    actual_seed = seed_sequence.entropy
+
     child_seeds = seed_sequence.spawn(num_simulations)
     seed_values = [int(child.generate_state(1)[0]) for child in child_seeds] if num_simulations > 0 else []
 
@@ -501,6 +504,8 @@ def simulate_season(
         if schedule_output is not None:
             test_schedule.clear()
             test_schedule.extend(schedule_output)
+
+    logger.info(f"Simulations completed using seed: {actual_seed}")
 
     return results
 


### PR DESCRIPTION
## Summary
- add per-simulation random number generators to the scoring and rating helpers so they can run independently
- run full season simulations in parallel with ProcessPoolExecutor while preserving deterministic behavior via SeedSequence
- replace lambda-based defaultdict factories with top-level helpers so standings can be shared across processes safely

## Testing
- python -m compileall simulate_season.py
- python - <<'PY'
from simulate_season import simulate_season
results = simulate_season(num_simulations=4, parallel=True)
print(len(results))
print(results[0]['super_bowl']['winner'])
PY
- python - <<'PY'
from simulate_season import simulate_season
res_seq = simulate_season(num_simulations=5, parallel=False, random_seed=123)
res_par = simulate_season(num_simulations=5, parallel=True, random_seed=123)
print(all(r['super_bowl']['winner'] == p['super_bowl']['winner'] for r, p in zip(res_seq, res_par)))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e34b0a09fc832d8b68f921f8490e28